### PR TITLE
docs: remove unnecessary config lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1248,9 +1248,6 @@ metadata:
   namespace: ${namespace}
   annotations:
     azure.workload.identity/client-id: ${appId}
-    azure.workload.identity/tenant-id: ${tenantId}
-  labels:
-    azure.workload.identity/use: "true"
 EOF
   else
     azwi serviceaccount create phase sa \

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -63,13 +63,6 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Create service account labels
-*/}}
-{{- define "todolist.serviceAccount.labels" -}}
-azure.workload.identity/use: "true"
-{{- end }}
-
-{{/*
 Frontend service and deployment labels
 */}}
 {{- define "todolist.frontend.labels" -}}
@@ -154,5 +147,4 @@ Service account annotations
 {{ end }}
 {{- end -}}
 azure.workload.identity/client-id: {{ .Values.serviceAccount.appId }}
-azure.workload.identity/tenant-id: {{ .Values.serviceAccount.tenantId }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,7 +15,6 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: "todolist-identity-sa"
   appId: ""
-  tenantId: ""
 
 configMap:
   aspNetCoreEnvironment: Docker


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

Hey @paolosalvatori, thank you for this content! 
I have removed `azure.workload.identity/use: "true"` from code samples, because its not valid for service account https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html#service-account

I have also removed `azure.workload.identity/tenant-id: ${tenantId}` annotation because it defaults to tenantId value set during wi installation.
```
    helm install $releaseName $repoName/$chartName \
        --namespace $namespace \
        --create-namespace \
        --set azureTenantID="$tenantId"
```
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```
